### PR TITLE
Relax parser to allow their typo

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,7 +12,7 @@ $(function() {
       return;
     }
     body = body.replace(/\r\n|\r/g, "\n");
-    var title = body.match(/\n((?:.*?)メンテナンス)のご連絡\n/)[1];
+    var title = body.match(/\n((?:.*?)メンテナンス)のご連絡\s*\n/)[1];
     title = title.replace(/^\s+/, '').replace(/\s+$/, '');
     var lines = body.match(/◆日時.*\n([\s\S]+?)\n\n/);
     var lines = lines[1];


### PR DESCRIPTION
Basically they write the title as

```
~　メンテナンスのご連絡
```

But I have faced another pattern...

```
~　メンテナンスのご連絡 
```

Please drag 🐭 around the line end
